### PR TITLE
po make: limit thread creation ability of libgomp

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -71,13 +71,13 @@ pull-po: $(POTFILE)
 	$(MAKE) update-gmo
 
 $(POTFILE): POTFILES $(POTFILE_DEPS)
-	$(XGETTEXT) -o $@-t $(XGETTEXT_ARGS) \
+	OMP_THREAD_LIMIT=1 $(XGETTEXT) -o $@-t $(XGETTEXT_ARGS) \
 	  --files-from=$(abs_srcdir)/POTFILES
 	$(SED) $(SED_PO_FIXUP_ARGS) < $@-t > $@
 	rm -f $@-t
 
 $(srcdir)/%.po: $(srcdir)/%.mini.po $(POTFILE)
-	$(MSGMERGE) --no-fuzzy-matching $< $(POTFILE) | \
+	OMP_THREAD_LIMIT=1 $(MSGMERGE) --no-fuzzy-matching $< $(POTFILE) | \
 	  $(SED) $(SED_PO_FIXUP_ARGS) > $@
 
 $(srcdir)/%.gmo: $(srcdir)/%.po


### PR DESCRIPTION
On large build systems with n number of cores, n squared
becomes a large number, blowing through user thread limits.
If n number of threads decides to create n number of threads,
it becomes problematic.

The symptom is seeing libvirt failing to build with message:
libgomp: Thread creation failed: Resource temporarily unavailable

Solution is to allow libgomp to only spawn one thread.  This keeps the
number of threads and the resources they use, reasonable.

Signed-off-by: Jim Somerville <Jim.Somerville@windriver.com>