### PR TITLE
Cherry picking changes to remove usage of deprecated function rbd_list

### DIFF
--- a/m4/virt-storage-rbd.m4
+++ b/m4/virt-storage-rbd.m4
@@ -33,6 +33,7 @@ AC_DEFUN([LIBVIRT_STORAGE_CHECK_RBD], [
       old_LIBS="$LIBS"
       LIBS="$LIBS $LIBRBD_LIBS"
       AC_CHECK_FUNCS([rbd_get_features],[],[LIBRBD_FOUND=no])
+      AC_CHECK_FUNCS([rbd_list2])
       LIBS="$old_LIBS"
     fi
 

--- a/src/conf/storage_conf.c
+++ b/src/conf/storage_conf.c
@@ -1098,7 +1098,7 @@ virStorageVolDefParseXML(virStoragePoolDefPtr pool,
                          xmlXPathContextPtr ctxt,
                          unsigned int flags)
 {
-    virStorageVolDefPtr ret;
+    virStorageVolDefPtr ret = NULL;
     virStorageVolOptionsPtr options;
     char *type = NULL;
     char *allocation = NULL;
@@ -1109,6 +1109,7 @@ virStorageVolDefParseXML(virStoragePoolDefPtr pool,
     xmlNodePtr *nodes = NULL;
     size_t i;
     int n;
+    VIR_AUTOPTR(virStorageVolDef) def = NULL;
 
     virCheckFlags(VIR_VOL_XML_PARSE_NO_CAPACITY |
                   VIR_VOL_XML_PARSE_OPT_CAPACITY, NULL);

--- a/src/conf/storage_conf.h
+++ b/src/conf/storage_conf.h
@@ -435,4 +435,7 @@ VIR_ENUM_DECL(virStoragePartedFs)
                  VIR_CONNECT_LIST_STORAGE_POOLS_FILTERS_AUTOSTART  | \
                  VIR_CONNECT_LIST_STORAGE_POOLS_FILTERS_POOL_TYPE)
 
+VIR_DEFINE_AUTOPTR_FUNC(virStoragePoolSource, virStoragePoolSourceFree);
+VIR_DEFINE_AUTOPTR_FUNC(virStorageVolDef, virStorageVolDefFree);
+
 #endif /* __VIR_STORAGE_CONF_H__ */

--- a/src/esx/esx_storage_backend_vmfs.c
+++ b/src/esx/esx_storage_backend_vmfs.c
@@ -838,7 +838,6 @@ esxStorageVolCreateXML(virStoragePoolPtr pool,
     virStorageVolPtr volume = NULL;
     esxPrivate *priv = pool->conn->privateData;
     virStoragePoolDef poolDef;
-    virStorageVolDefPtr def = NULL;
     char *tmp;
     char *unescapedDatastorePath = NULL;
     char *unescapedDirectoryName = NULL;
@@ -854,6 +853,7 @@ esxStorageVolCreateXML(virStoragePoolPtr pool,
     char *taskInfoErrorMessage = NULL;
     char *uuid_string = NULL;
     char *key = NULL;
+    VIR_AUTOPTR(virStorageVolDef) def = NULL;
 
     virCheckFlags(0, NULL);
 
@@ -1026,7 +1026,6 @@ esxStorageVolCreateXML(virStoragePoolPtr pool,
         virtualDiskSpec->adapterType = NULL;
     }
 
-    virStorageVolDefFree(def);
     VIR_FREE(unescapedDatastorePath);
     VIR_FREE(unescapedDirectoryName);
     VIR_FREE(unescapedDirectoryAndFileName);
@@ -1056,7 +1055,6 @@ esxStorageVolCreateXMLFrom(virStoragePoolPtr pool,
     esxPrivate *priv = pool->conn->privateData;
     virStoragePoolDef poolDef;
     char *sourceDatastorePath = NULL;
-    virStorageVolDefPtr def = NULL;
     char *tmp;
     char *unescapedDatastorePath = NULL;
     char *unescapedDirectoryName = NULL;
@@ -1071,6 +1069,7 @@ esxStorageVolCreateXMLFrom(virStoragePoolPtr pool,
     char *taskInfoErrorMessage = NULL;
     char *uuid_string = NULL;
     char *key = NULL;
+    VIR_AUTOPTR(virStorageVolDef) def = NULL;
 
     virCheckFlags(0, NULL);
 
@@ -1209,7 +1208,6 @@ esxStorageVolCreateXMLFrom(virStoragePoolPtr pool,
 
  cleanup:
     VIR_FREE(sourceDatastorePath);
-    virStorageVolDefFree(def);
     VIR_FREE(unescapedDatastorePath);
     VIR_FREE(unescapedDirectoryName);
     VIR_FREE(unescapedDirectoryAndFileName);

--- a/src/phyp/phyp_driver.c
+++ b/src/phyp/phyp_driver.c
@@ -1961,11 +1961,11 @@ phypStorageVolCreateXML(virStoragePoolPtr pool,
 {
     virCheckFlags(0, NULL);
 
-    virStorageVolDefPtr voldef = NULL;
     virStoragePoolDefPtr spdef = NULL;
     virStorageVolPtr vol = NULL;
     virStorageVolPtr dup_vol = NULL;
     char *key = NULL;
+    VIR_AUTOPTR(virStorageVolDef) voldef = NULL;
 
     if (VIR_ALLOC(spdef) < 0)
         return NULL;
@@ -2045,7 +2045,6 @@ phypStorageVolCreateXML(virStoragePoolPtr pool,
 
  err:
     VIR_FREE(key);
-    virStorageVolDefFree(voldef);
     virStoragePoolDefFree(spdef);
     virObjectUnref(vol);
     return NULL;

--- a/src/storage/storage_backend_gluster.c
+++ b/src/storage/storage_backend_gluster.c
@@ -242,12 +242,12 @@ virStorageBackendGlusterRefreshVol(virStorageBackendGlusterStatePtr state,
                                    virStorageVolDefPtr *volptr)
 {
     int ret = -1;
-    virStorageVolDefPtr vol = NULL;
     glfs_fd_t *fd = NULL;
     virStorageSourcePtr meta = NULL;
     char *header = NULL;
     ssize_t len;
     int backingFormat;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     *volptr = NULL;
 
@@ -333,7 +333,6 @@ virStorageBackendGlusterRefreshVol(virStorageBackendGlusterStatePtr state,
     ret = 0;
  cleanup:
     virStorageSourceFree(meta);
-    virStorageVolDefFree(vol);
     if (fd)
         glfs_close(fd);
     VIR_FREE(header);

--- a/src/storage/storage_backend_iscsi_direct.c
+++ b/src/storage/storage_backend_iscsi_direct.c
@@ -307,22 +307,21 @@ virISCSIDirectRefreshVol(virStoragePoolObjPtr pool,
                          char *portal)
 {
     virStoragePoolDefPtr def = virStoragePoolObjGetDef(pool);
-    virStorageVolDefPtr vol = NULL;
     uint32_t block_size;
     uint32_t nb_block;
-    int ret = -1;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     virStoragePoolObjClearVols(pool);
     if (virISCSIDirectTestUnitReady(iscsi, lun) < 0)
-        goto cleanup;
+        return -1;
 
     if (VIR_ALLOC(vol) < 0)
-        goto cleanup;
+        return -1;
 
     vol->type = VIR_STORAGE_VOL_NETWORK;
 
     if (virISCSIDirectGetVolumeCapacity(iscsi, lun, &block_size, &nb_block) < 0)
-        goto cleanup;
+        return -1;
 
     vol->target.capacity = block_size * nb_block;
     vol->target.allocation = block_size * nb_block;
@@ -330,17 +329,13 @@ virISCSIDirectRefreshVol(virStoragePoolObjPtr pool,
     def->allocation += vol->target.allocation;
 
     if (virISCSIDirectSetVolumeAttributes(pool, vol, lun, portal) < 0)
-        goto cleanup;
+        return -1;
 
     if (virStoragePoolObjAddVol(pool, vol) < 0)
-        goto cleanup;
-
+        return -1;
     vol = NULL;
 
-    ret = 0;
- cleanup:
-    virStorageVolDefFree(vol);
-    return ret;
+    return 0;
 }
 
 static int

--- a/src/storage/storage_backend_mpath.c
+++ b/src/storage/storage_backend_mpath.c
@@ -49,42 +49,36 @@ virStorageBackendMpathNewVol(virStoragePoolObjPtr pool,
                              const char *dev)
 {
     virStoragePoolDefPtr def = virStoragePoolObjGetDef(pool);
-    virStorageVolDefPtr vol;
-    int ret = -1;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     if (VIR_ALLOC(vol) < 0)
-        goto cleanup;
+        return -1;
 
     vol->type = VIR_STORAGE_VOL_BLOCK;
 
     if (virAsprintf(&(vol->name), "dm-%u", devnum) < 0)
-        goto cleanup;
+        return -1;
 
     if (virAsprintf(&vol->target.path, "/dev/%s", dev) < 0)
-        goto cleanup;
+        return -1;
 
     if (virStorageBackendUpdateVolInfo(vol, true,
                                        VIR_STORAGE_VOL_OPEN_DEFAULT, 0) < 0) {
-        goto cleanup;
+        return -1;
     }
 
     /* XXX should use logical unit's UUID instead */
     if (VIR_STRDUP(vol->key, vol->target.path) < 0)
-        goto cleanup;
+        return -1;
 
     if (virStoragePoolObjAddVol(pool, vol) < 0)
-        goto cleanup;
+        return -1;
 
     def->capacity += vol->target.capacity;
     def->allocation += vol->target.allocation;
-    ret = 0;
+    vol = NULL;
 
- cleanup:
-
-    if (ret != 0)
-        virStorageVolDefFree(vol);
-
-    return ret;
+    return 0;
 }
 
 

--- a/src/storage/storage_backend_rbd.c
+++ b/src/storage/storage_backend_rbd.c
@@ -574,15 +574,14 @@ virStorageBackendRBDRefreshPool(virStoragePoolObjPtr pool)
             if (r == -ENOENT || r == -ETIMEDOUT)
                 continue;
 
-            virStorageVolDefFree(vol);
             goto cleanup;
         }
 
         if (virStoragePoolObjAddVol(pool, vol) < 0) {
-            virStorageVolDefFree(vol);
             virStoragePoolObjClearVols(pool);
             goto cleanup;
         }
+        vol = NULL;
     }
 
     VIR_DEBUG("Found %zu images in RBD pool %s",

--- a/src/storage/storage_backend_rbd.c
+++ b/src/storage/storage_backend_rbd.c
@@ -419,18 +419,68 @@ volStorageBackendRBDRefreshVolInfo(virStorageVolDefPtr vol,
     return ret;
 }
 
+
+static char **
+virStorageBackendRBDGetVolNames(virStorageBackendRBDStatePtr ptr)
+{
+    char **names = NULL;
+    size_t nnames = 0;
+    int rc;
+    size_t max_size = 1024;
+    VIR_AUTOFREE(char *) namebuf = NULL;
+    const char *name;
+
+    while (true) {
+        if (VIR_ALLOC_N(namebuf, max_size) < 0)
+            goto error;
+
+        rc = rbd_list(ptr->ioctx, namebuf, &max_size);
+        if (rc >= 0)
+            break;
+        if (rc != -ERANGE) {
+            virReportSystemError(-rc, "%s", _("Unable to list RBD images"));
+            goto error;
+        }
+        VIR_FREE(namebuf);
+    }
+
+    for (name = namebuf; name < namebuf + max_size;) {
+        VIR_AUTOFREE(char *) namedup = NULL;
+
+        if (STREQ(name, ""))
+            break;
+
+        if (VIR_STRDUP(namedup, name) < 0)
+            goto error;
+
+        if (VIR_APPEND_ELEMENT(names, nnames, namedup) < 0)
+            goto error;
+
+        name += strlen(name) + 1;
+    }
+
+    if (VIR_EXPAND_N(names, nnames, 1) < 0)
+        goto error;
+
+    return names;
+
+ error:
+    virStringListFreeCount(names, nnames);
+    return NULL;
+}
+
+
 static int
 virStorageBackendRBDRefreshPool(virStoragePoolObjPtr pool)
 {
-    size_t max_size = 1024;
     int ret = -1;
-    int len = -1;
     int r = 0;
-    char *name, *names = NULL;
     virStoragePoolDefPtr def = virStoragePoolObjGetDef(pool);
     virStorageBackendRBDStatePtr ptr = NULL;
     struct rados_cluster_stat_t clusterstat;
     struct rados_pool_stat_t poolstat;
+    char **names = NULL;
+    size_t i;
 
     if (!(ptr = virStorageBackendRBDNewState(pool)))
         goto cleanup;
@@ -455,35 +505,16 @@ virStorageBackendRBDRefreshPool(virStoragePoolObjPtr pool)
               def->source.name, clusterstat.kb, clusterstat.kb_avail,
               poolstat.num_bytes);
 
-    while (true) {
-        if (VIR_ALLOC_N(names, max_size) < 0)
-            goto cleanup;
+    if (!(names = virStorageBackendRBDGetVolNames(ptr)))
+        goto cleanup;
 
-        len = rbd_list(ptr->ioctx, names, &max_size);
-        if (len >= 0)
-            break;
-        if (len != -ERANGE) {
-            VIR_WARN("%s", "A problem occurred while listing RBD images");
-            goto cleanup;
-        }
-        VIR_FREE(names);
-    }
-
-    for (name = names; name < names + max_size;) {
-        virStorageVolDefPtr vol;
-
-        if (STREQ(name, ""))
-            break;
+    for (i = 0; names[i] != NULL; i++) {
+        VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
         if (VIR_ALLOC(vol) < 0)
             goto cleanup;
 
-        if (VIR_STRDUP(vol->name, name) < 0) {
-            VIR_FREE(vol);
-            goto cleanup;
-        }
-
-        name += strlen(name) + 1;
+        VIR_STEAL_PTR(vol->name, names[i]);
 
         r = volStorageBackendRBDRefreshVolInfo(vol, pool, ptr);
 
@@ -517,7 +548,7 @@ virStorageBackendRBDRefreshPool(virStoragePoolObjPtr pool)
     ret = 0;
 
  cleanup:
-    VIR_FREE(names);
+    virStringListFree(names);
     virStorageBackendRBDFreeState(&ptr);
     return ret;
 }

--- a/src/storage/storage_backend_rbd.c
+++ b/src/storage/storage_backend_rbd.c
@@ -420,6 +420,48 @@ volStorageBackendRBDRefreshVolInfo(virStorageVolDefPtr vol,
 }
 
 
+#ifdef HAVE_RBD_LIST2
+static char **
+virStorageBackendRBDGetVolNames(virStorageBackendRBDStatePtr ptr)
+{
+    char **names = NULL;
+    size_t nnames = 0;
+    int rc;
+    rbd_image_spec_t *images = NULL;
+    size_t nimages = 16;
+    size_t i;
+
+    while (true) {
+        if (VIR_ALLOC_N(images, nimages) < 0)
+            goto error;
+
+        rc = rbd_list2(ptr->ioctx, images, &nimages);
+        if (rc >= 0)
+            break;
+        if (rc != -ERANGE) {
+            virReportSystemError(-rc, "%s", _("Unable to list RBD images"));
+            goto error;
+        }
+    }
+
+    if (VIR_ALLOC_N(names, nimages + 1) < 0)
+        goto error;
+    nnames = nimages;
+
+    for (i = 0; i < nimages; i++)
+        VIR_STEAL_PTR(names[i], images->name);
+
+    return names;
+
+ error:
+    virStringListFreeCount(names, nnames);
+    rbd_image_spec_list_cleanup(images, nimages);
+    VIR_FREE(images);
+    return NULL;
+}
+
+#else /* ! HAVE_RBD_LIST2 */
+
 static char **
 virStorageBackendRBDGetVolNames(virStorageBackendRBDStatePtr ptr)
 {
@@ -468,6 +510,7 @@ virStorageBackendRBDGetVolNames(virStorageBackendRBDStatePtr ptr)
     virStringListFreeCount(names, nnames);
     return NULL;
 }
+#endif /* ! HAVE_RBD_LIST2 */
 
 
 static int

--- a/src/storage/storage_backend_sheepdog.c
+++ b/src/storage/storage_backend_sheepdog.c
@@ -113,30 +113,27 @@ virStorageBackendSheepdogAddHostArg(virCommandPtr cmd,
 static int
 virStorageBackendSheepdogAddVolume(virStoragePoolObjPtr pool, const char *diskInfo)
 {
-    virStorageVolDefPtr vol = NULL;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     if (diskInfo == NULL) {
         virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
                        _("Missing disk info when adding volume"));
-        goto error;
+        return -1;
     }
 
     if (VIR_ALLOC(vol) < 0 || VIR_STRDUP(vol->name, diskInfo) < 0)
-        goto error;
+        return -1;
 
     vol->type = VIR_STORAGE_VOL_NETWORK;
 
     if (virStorageBackendSheepdogRefreshVol(pool, vol) < 0)
-        goto error;
+        return -1;
 
     if (virStoragePoolObjAddVol(pool, vol) < 0)
-        goto error;
+        return -1;
+    vol = NULL;
 
     return 0;
-
- error:
-    virStorageVolDefFree(vol);
-    return -1;
 }
 
 static int

--- a/src/storage/storage_driver.c
+++ b/src/storage/storage_driver.c
@@ -1830,8 +1830,8 @@ storageVolCreateXML(virStoragePoolPtr pool,
     virStoragePoolObjPtr obj;
     virStoragePoolDefPtr def;
     virStorageBackendPtr backend;
-    virStorageVolDefPtr voldef = NULL;
     virStorageVolPtr vol = NULL, newvol = NULL;
+    VIR_AUTOPTR(virStorageVolDef) voldef = NULL;
 
     virCheckFlags(VIR_STORAGE_VOL_CREATE_PREALLOC_METADATA, NULL);
 
@@ -1952,7 +1952,6 @@ storageVolCreateXML(virStoragePoolPtr pool,
 
  cleanup:
     virObjectUnref(newvol);
-    virStorageVolDefFree(voldef);
     virStoragePoolObjEndAPI(&obj);
     return vol;
 }
@@ -1968,11 +1967,11 @@ storageVolCreateXMLFrom(virStoragePoolPtr pool,
     virStoragePoolObjPtr objsrc = NULL;
     virStorageBackendPtr backend;
     virStorageVolDefPtr voldefsrc = NULL;
-    virStorageVolDefPtr voldef = NULL;
     virStorageVolDefPtr shadowvol = NULL;
     virStorageVolPtr newvol = NULL;
     virStorageVolPtr vol = NULL;
     int buildret;
+    VIR_AUTOPTR(virStorageVolDef) voldef = NULL;
 
     virCheckFlags(VIR_STORAGE_VOL_CREATE_PREALLOC_METADATA |
                   VIR_STORAGE_VOL_CREATE_REFLINK,
@@ -2146,7 +2145,6 @@ storageVolCreateXMLFrom(virStoragePoolPtr pool,
 
  cleanup:
     virObjectUnref(newvol);
-    virStorageVolDefFree(voldef);
     VIR_FREE(shadowvol);
     virStoragePoolObjEndAPI(&obj);
     virStoragePoolObjEndAPI(&objsrc);

--- a/src/storage/storage_util.c
+++ b/src/storage/storage_util.c
@@ -3597,10 +3597,10 @@ virStorageBackendRefreshLocal(virStoragePoolObjPtr pool)
     struct dirent *ent;
     struct statvfs sb;
     struct stat statbuf;
-    virStorageVolDefPtr vol = NULL;
     virStorageSourcePtr target = NULL;
     int direrr;
     int fd = -1, ret = -1;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     if (virDirOpen(&dir, def->target.path) < 0)
         goto cleanup;
@@ -3692,7 +3692,6 @@ virStorageBackendRefreshLocal(virStoragePoolObjPtr pool)
  cleanup:
     VIR_DIR_CLOSE(dir);
     VIR_FORCE_CLOSE(fd);
-    virStorageVolDefFree(vol);
     virStorageSourceFree(target);
     if (ret < 0)
         virStoragePoolObjClearVols(pool);
@@ -3756,9 +3755,9 @@ virStorageBackendSCSINewLun(virStoragePoolObjPtr pool,
                             const char *dev)
 {
     virStoragePoolDefPtr def = virStoragePoolObjGetDef(pool);
-    virStorageVolDefPtr vol = NULL;
     char *devpath = NULL;
     int retval = -1;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     /* Check if the pool is using a stable target path. The call to
      * virStorageBackendStablePath will fail if the pool target path
@@ -3835,7 +3834,6 @@ virStorageBackendSCSINewLun(virStoragePoolObjPtr pool,
     retval = 0;
 
  cleanup:
-    virStorageVolDefFree(vol);
     VIR_FREE(devpath);
     return retval;
 }

--- a/src/test/test_driver.c
+++ b/src/test/test_driver.c
@@ -1038,7 +1038,7 @@ testOpenVolumesForPool(const char *file,
     size_t i;
     int num, ret = -1;
     xmlNodePtr *nodes = NULL;
-    virStorageVolDefPtr volDef = NULL;
+    VIR_AUTOPTR(virStorageVolDef) volDef = NULL;
 
     /* Find storage volumes */
     if (virAsprintf(&vol_xpath, "/node/pool[%d]/volume", objidx) < 0)
@@ -1077,7 +1077,6 @@ testOpenVolumesForPool(const char *file,
 
     ret = 0;
  error:
-    virStorageVolDefFree(volDef);
     VIR_FREE(nodes);
     return ret;
 }
@@ -5087,8 +5086,8 @@ testStorageVolCreateXML(virStoragePoolPtr pool,
     testDriverPtr privconn = pool->conn->privateData;
     virStoragePoolObjPtr obj;
     virStoragePoolDefPtr def;
-    virStorageVolDefPtr privvol = NULL;
     virStorageVolPtr ret = NULL;
+    VIR_AUTOPTR(virStorageVolDef) privvol = NULL;
 
     virCheckFlags(0, NULL);
 
@@ -5132,7 +5131,6 @@ testStorageVolCreateXML(virStoragePoolPtr pool,
     privvol = NULL;
 
  cleanup:
-    virStorageVolDefFree(privvol);
     virStoragePoolObjEndAPI(&obj);
     return ret;
 }
@@ -5147,8 +5145,9 @@ testStorageVolCreateXMLFrom(virStoragePoolPtr pool,
     testDriverPtr privconn = pool->conn->privateData;
     virStoragePoolObjPtr obj;
     virStoragePoolDefPtr def;
-    virStorageVolDefPtr privvol = NULL, origvol = NULL;
+    virStorageVolDefPtr origvol = NULL;
     virStorageVolPtr ret = NULL;
+    VIR_AUTOPTR(virStorageVolDef) privvol = NULL;
 
     virCheckFlags(0, NULL);
 
@@ -5200,7 +5199,6 @@ testStorageVolCreateXMLFrom(virStoragePoolPtr pool,
     privvol = NULL;
 
  cleanup:
-    virStorageVolDefFree(privvol);
     virStoragePoolObjEndAPI(&obj);
     return ret;
 }

--- a/src/vbox/vbox_storage.c
+++ b/src/vbox/vbox_storage.c
@@ -402,7 +402,6 @@ vboxStorageVolCreateXML(virStoragePoolPtr pool,
                         const char *xml, unsigned int flags)
 {
     vboxDriverPtr data = pool->conn->privateData;
-    virStorageVolDefPtr def = NULL;
     PRUnichar *hddFormatUtf16 = NULL;
     PRUnichar *hddNameUtf16 = NULL;
     virStoragePoolDef poolDef;
@@ -416,6 +415,7 @@ vboxStorageVolCreateXML(virStoragePoolPtr pool,
     PRUint32 variant = HardDiskVariant_Standard;
     resultCodeUnion resultCode;
     virStorageVolPtr ret = NULL;
+    VIR_AUTOPTR(virStorageVolDef) def = NULL;
 
     if (!data->vboxObj)
         return ret;
@@ -502,7 +502,6 @@ vboxStorageVolCreateXML(virStoragePoolPtr pool,
     VBOX_RELEASE(progress);
     VBOX_UTF16_FREE(hddFormatUtf16);
     VBOX_UTF16_FREE(hddNameUtf16);
-    virStorageVolDefFree(def);
     return ret;
 }
 

--- a/tests/storagebackendsheepdogtest.c
+++ b/tests/storagebackendsheepdogtest.c
@@ -98,7 +98,7 @@ test_vdi_list_parser(const void *opaque)
     int ret = -1;
     char *output = NULL;
     virStoragePoolDefPtr pool = NULL;
-    virStorageVolDefPtr vol = NULL;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
 
     if (!(pool = virStoragePoolDefParseFile(data->poolxml)))
         goto cleanup;
@@ -125,7 +125,6 @@ test_vdi_list_parser(const void *opaque)
  cleanup:
     VIR_FREE(output);
     virStoragePoolDefFree(pool);
-    virStorageVolDefFree(vol);
     return ret;
 }
 

--- a/tests/storagevolxml2argvtest.c
+++ b/tests/storagevolxml2argvtest.c
@@ -48,10 +48,11 @@ testCompareXMLToArgvFiles(bool shouldFail,
 
     virCommandPtr cmd = NULL;
 
-    virStorageVolDefPtr vol = NULL, inputvol = NULL;
     virStoragePoolDefPtr def = NULL;
     virStoragePoolDefPtr inputpool = NULL;
     virStoragePoolObjPtr obj = NULL;
+    VIR_AUTOPTR(virStorageVolDef) vol = NULL;
+    VIR_AUTOPTR(virStorageVolDef) inputvol = NULL;
 
     if (!(def = virStoragePoolDefParseFile(poolxml)))
         goto cleanup;
@@ -138,8 +139,6 @@ testCompareXMLToArgvFiles(bool shouldFail,
 
  cleanup:
     virStoragePoolDefFree(inputpool);
-    virStorageVolDefFree(vol);
-    virStorageVolDefFree(inputvol);
     virCommandFree(cmd);
     VIR_FREE(actualCmdline);
     virStoragePoolObjEndAPI(&obj);

--- a/tests/storagevolxml2xmltest.c
+++ b/tests/storagevolxml2xmltest.c
@@ -23,7 +23,7 @@ testCompareXMLToXMLFiles(const char *poolxml, const char *inxml,
     char *actual = NULL;
     int ret = -1;
     virStoragePoolDefPtr pool = NULL;
-    virStorageVolDefPtr dev = NULL;
+    VIR_AUTOPTR(virStorageVolDef) dev = NULL;
 
     if (!(pool = virStoragePoolDefParseFile(poolxml)))
         goto fail;
@@ -42,7 +42,6 @@ testCompareXMLToXMLFiles(const char *poolxml, const char *inxml,
  fail:
     VIR_FREE(actual);
     virStoragePoolDefFree(pool);
-    virStorageVolDefFree(dev);
     return ret;
 }
 


### PR DESCRIPTION
Cherry picked the following commit from upstream to remove the usage of the deprecated function rbd_list from librbd inside ceph in favor to rbd_list2.

Commits:
* libvirt/libvirt@28c8403
* libvirt/libvirt@3aa190f 
* https://github.com/libvirt/libvirt/commit/1f20da92d838532f6a7639d84b292f788ea1391c
